### PR TITLE
Added a snippet for adding props in a styled components css

### DIFF
--- a/snippets/styled-components-snippets.cson
+++ b/snippets/styled-components-snippets.cson
@@ -1,4 +1,4 @@
-'.source.js':
+'.source.js, .source.jsx, .source.ts, .source.tsx':
 
   "import styled from 'styled-components'":
     'prefix': 'imsc'
@@ -106,7 +106,7 @@
                 ${1}
               `;
             """
-  
+
   'Styled-Component with attributes':
     'prefix': 'scattrs'
     'body': """
@@ -125,4 +125,10 @@
               })`
                 ${5}
               `;
+            """
+
+  'Props':
+    'prefix': 'scp'
+    'body': """
+              ${props => props.${1}};
             """


### PR DESCRIPTION
Thanks Jonk for these styled components snippets. Just started to use it.

I added the prefix "scp" for a props snippet, since I often use props in my styled component. 

Additionally I added some more file extensions, so your snippets work in jsx, tx and ts files as well. 

I hope this is helpful.
